### PR TITLE
Add staging release workflow

### DIFF
--- a/.github/workflows/get_aws_images.yml
+++ b/.github/workflows/get_aws_images.yml
@@ -98,7 +98,7 @@ jobs:
 
   list_images:
     name: "List Images"
-    needs: list_regions
+    needs: [list_regions, setup]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -106,9 +106,18 @@ jobs:
       matrix: ${{fromJSON(needs.list_regions.outputs.matrix)}}
     env:
       REGION: ${{ matrix.region }}
+      ENVIRONMENT: ${{ needs.setup.outputs.environment }}        
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout latest tagged release
+        if: env.ENVIRONMENT == 'production'
+        run: |
+          LATEST_RELEASE=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout $LATEST_RELEASE
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
@@ -144,6 +153,14 @@ jobs:
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout latest tagged release
+        if: env.ENVIRONMENT == 'production'
+        run: |
+          LATEST_RELEASE=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout $LATEST_RELEASE         
 
       - name: Download image data artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/get_aws_images.yml
+++ b/.github/workflows/get_aws_images.yml
@@ -31,7 +31,7 @@ jobs:
     name: Setup workflow envs
     runs-on: ubuntu-latest
     outputs:
-      environment: ${{ steps.set-environment.ouputs.environment }}
+      environment: ${{ steps.set-environment.outputs.environment }}
       bucket: ${{ steps.set-bucket.outputs.bucket }}
     steps:
       # Only set target environment to production if the workflow is triggered by
@@ -54,7 +54,6 @@ jobs:
           else
             echo "bucket=cid-bucket-staging" >> $GITHUB_OUTPUT
           fi
-
 
   list_regions:
     name: "List Regions"

--- a/.github/workflows/get_aws_images.yml
+++ b/.github/workflows/get_aws_images.yml
@@ -3,7 +3,19 @@ name: AWS Images
 on:
   schedule:
     - cron: "45 3 * * *"
+  push:
+    branches:
+      - main
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Choose your target environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - 'production'
+          - 'staging'
 
 permissions:
   actions: write
@@ -15,11 +27,41 @@ env:
   AWS_PAGER: ""
 
 jobs:
+  setup:
+    name: Setup workflow envs
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.set-environment.ouputs.environment }}
+      bucket: ${{ steps.set-bucket.outputs.bucket }}
+    steps:
+      # Set target environment to production if the workflow is triggered by
+      # a scheduled execution or workflow_dispatch with production input selected
+      - name: Setup target environment
+        id: set-environment
+        run: |
+          if [ ${{ github.event_name == 'schedule' }} || ${{ inputs.environment }} == "production" ]; then
+            echo "environment=production"
+          else
+            echo "environment=staging"
+          fi
+
+      - name: Setup target bucket
+        # Set target bucket according to target environment
+        id: set-bucket
+        run: |
+          if [ ${{ steps.set-environment.ouputs.environment }} == "production" ]; then
+            echo "bucket=cloudx-json-bucket"
+          else
+            echo "bucket=cid-bucket-staging"
+          fi
+
+
   list_regions:
     name: "List Regions"
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
@@ -126,7 +168,7 @@ jobs:
             --delete \
             --no-progress \
             --content-type application/json \
-            $(pwd)/raw/aws/ s3://cloudx-json-bucket/raw/aws/
+            $(pwd)/raw/aws/ s3://${{needs.setup.outputs.bucket}}/raw/aws/
 
   launch_parser:
     name: "Launch parser"
@@ -139,3 +181,4 @@ jobs:
         run: gh workflow run parse.yml
         env:
           GH_TOKEN: ${{ github.token }}
+

--- a/.github/workflows/get_aws_images.yml
+++ b/.github/workflows/get_aws_images.yml
@@ -34,7 +34,7 @@ jobs:
       environment: ${{ steps.set-environment.ouputs.environment }}
       bucket: ${{ steps.set-bucket.outputs.bucket }}
     steps:
-      # Set target environment to production if the workflow is triggered by
+      # Only set target environment to production if the workflow is triggered by
       # a scheduled execution or workflow_dispatch with production input selected
       - name: Setup target environment
         id: set-environment
@@ -49,7 +49,7 @@ jobs:
         # Set target bucket according to target environment
         id: set-bucket
         run: |
-          if [ ${{ steps.set-environment.ouputs.environment }} == "production" ]; then
+          if [ ${{ github.event_name == 'schedule' }} || ${{ inputs.environment }} == "production" ]; then
             echo "bucket=cloudx-json-bucket"
           else
             echo "bucket=cid-bucket-staging"
@@ -69,6 +69,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout latest tagged release
+        if: ${{ needs.setup.outputs.environment }} == 'production'
         run: |
           LATEST_RELEASE=$(git describe --tags `git rev-list --tags --max-count=1`)
           git checkout $LATEST_RELEASE
@@ -148,12 +149,23 @@ jobs:
       - name: Install awscli v2
         uses: unfor19/install-aws-cli-action@v1
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials for production
         uses: aws-actions/configure-aws-credentials@v2
+        if: ${{ needs.setup.outputs.environment }} == 'production'
         with:
           role-to-assume: arn:aws:iam::426579533370:role/github_actions_image_retriever
           role-duration-seconds: 1800
           aws-region: us-east-1
+
+      - name: Configure AWS credentials for staging
+        uses: aws-actions/configure-aws-credentials@v2
+        if: ${{ needs.setup.outputs.environment }} == 'production'
+        with:
+          # TODO: Add proper role
+          role-to-assume: arn:aws:iam::426579533370:role/github_actions_image_retriever
+          role-duration-seconds: 1800
+          aws-region: us-east-1
+            
 
       - name: Decompress artifacts
         run: |

--- a/.github/workflows/get_aws_images.yml
+++ b/.github/workflows/get_aws_images.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: 'Choose your target environment'
+        description: 'Choose your deployment target environment'
         required: true
         default: 'staging'
         type: choice
@@ -39,29 +39,31 @@ jobs:
       - name: Setup target environment
         id: set-environment
         run: |
-          if [ ${{ github.event_name == 'schedule' }} || ${{ inputs.environment }} == "production" ]; then
-            echo "environment=production"
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.environment }}" = "production" ]; then
+            echo "environment=production" >> $GITHUB_OUTPUT
           else
-            echo "environment=staging"
+            echo "environment=staging" >> $GITHUB_OUTPUT
           fi
 
       - name: Setup target bucket
         # Set target bucket according to target environment
         id: set-bucket
         run: |
-          if [ ${{ github.event_name == 'schedule' }} || ${{ inputs.environment }} == "production" ]; then
-            echo "bucket=cloudx-json-bucket"
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.environment }}" = "production" ]; then
+            echo "bucket=cloudx-json-bucket" >> $GITHUB_OUTPUT
           else
-            echo "bucket=cid-bucket-staging"
+            echo "bucket=cid-bucket-staging" >> $GITHUB_OUTPUT
           fi
 
 
   list_regions:
     name: "List Regions"
     runs-on: ubuntu-latest
+    needs: setup
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-
+    env:
+      ENVIRONMENT: ${{ needs.setup.outputs.environment }}
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
@@ -69,7 +71,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout latest tagged release
-        if: ${{ needs.setup.outputs.environment }} == 'production'
+        if: env.ENVIRONMENT == 'production'
         run: |
           LATEST_RELEASE=$(git describe --tags `git rev-list --tags --max-count=1`)
           git checkout $LATEST_RELEASE
@@ -136,7 +138,10 @@ jobs:
   upload_data:
     name: "Upload Data"
     runs-on: ubuntu-latest
-    needs: [list_images]
+    needs: [list_images, setup]
+    env:
+      ENVIRONMENT: ${{ needs.setup.outputs.environment }}      
+      BUCKET: ${{ needs.setup.outputs.bucket }}      
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
@@ -151,7 +156,7 @@ jobs:
 
       - name: Configure AWS credentials for production
         uses: aws-actions/configure-aws-credentials@v2
-        if: ${{ needs.setup.outputs.environment }} == 'production'
+        if: env.ENVIRONMENT == 'production'
         with:
           role-to-assume: arn:aws:iam::426579533370:role/github_actions_image_retriever
           role-duration-seconds: 1800
@@ -159,10 +164,9 @@ jobs:
 
       - name: Configure AWS credentials for staging
         uses: aws-actions/configure-aws-credentials@v2
-        if: ${{ needs.setup.outputs.environment }} == 'production'
+        if: env.ENVIRONMENT == 'staging'
         with:
-          # TODO: Add proper role
-          role-to-assume: arn:aws:iam::426579533370:role/github_actions_image_retriever
+          role-to-assume: arn:aws:iam::426579533370:role/github_actions_cloud_image_directory_staging
           role-duration-seconds: 1800
           aws-region: us-east-1
             
@@ -180,7 +184,7 @@ jobs:
             --delete \
             --no-progress \
             --content-type application/json \
-            $(pwd)/raw/aws/ s3://${{needs.setup.outputs.bucket}}/raw/aws/
+            $(pwd)/raw/aws/ s3://${BUCKET}/raw/aws/
 
   launch_parser:
     name: "Launch parser"

--- a/.github/workflows/get_azure_images.yml
+++ b/.github/workflows/get_azure_images.yml
@@ -3,7 +3,19 @@ name: Azure Images
 on:
   schedule:
     - cron: "45 4 * * *"
+  push:
+    branches:
+      - main      
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Choose your deployment target environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - 'production'
+          - 'staging'
 
 permissions:
   actions: write
@@ -15,11 +27,42 @@ env:
   AWS_PAGER: ""
 
 jobs:
+  setup:
+    name: Setup workflow envs
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.set-environment.outputs.environment }}
+      bucket: ${{ steps.set-bucket.outputs.bucket }}
+    steps:
+      # Only set target environment to production if the workflow is triggered by
+      # a scheduled execution or workflow_dispatch with production input selected
+      - name: Setup target environment
+        id: set-environment
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.environment }}" = "production" ]; then
+            echo "environment=production" >> $GITHUB_OUTPUT
+          else
+            echo "environment=staging" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup target bucket
+        # Set target bucket according to target environment
+        id: set-bucket
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.environment }}" = "production" ]; then
+            echo "bucket=cloudx-json-bucket" >> $GITHUB_OUTPUT
+          else
+            echo "bucket=cid-bucket-staging" >> $GITHUB_OUTPUT
+          fi
+          
   list_regions:
     name: "List Regions"
     runs-on: ubuntu-latest
+    needs: setup
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+    env:
+      ENVIRONMENT: ${{ needs.setup.outputs.environment }}
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
@@ -27,6 +70,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout latest tagged release
+        if: env.ENVIRONMENT == 'production'
         run: |
           LATEST_RELEASE=$(git describe --tags `git rev-list --tags --max-count=1`)
           git checkout $LATEST_RELEASE
@@ -58,7 +102,7 @@ jobs:
 
   list_images:
     name: "List Images"
-    needs: list_regions
+    needs: [list_regions, setup]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -66,9 +110,18 @@ jobs:
       matrix: ${{fromJSON(needs.list_regions.outputs.matrix)}}
     env:
       REGION: ${{ matrix.region }}
+      ENVIRONMENT: ${{ needs.setup.outputs.environment }}        
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout latest tagged release
+        if: env.ENVIRONMENT == 'production'
+        run: |
+          LATEST_RELEASE=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout $LATEST_RELEASE
 
       - name: "Az CLI login"
         uses: azure/login@v1
@@ -95,10 +148,21 @@ jobs:
   upload_data:
     name: "Upload Data"
     runs-on: ubuntu-latest
-    needs: [list_images]
+    needs: [list_images, setup]
+    env:
+      ENVIRONMENT: ${{ needs.setup.outputs.environment }}
+      BUCKET: ${{ needs.setup.outputs.bucket }}        
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout latest tagged release
+        if: env.ENVIRONMENT == 'production'
+        run: |
+          LATEST_RELEASE=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout $LATEST_RELEASE
 
       - name: Download image data artifacts
         uses: actions/download-artifact@v3
@@ -108,10 +172,19 @@ jobs:
       - name: Install awscli v2
         uses: unfor19/install-aws-cli-action@v1
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials for production
         uses: aws-actions/configure-aws-credentials@v2
+        if: env.ENVIRONMENT == 'production'
         with:
           role-to-assume: arn:aws:iam::426579533370:role/github_actions_image_retriever
+          role-duration-seconds: 1800
+          aws-region: us-east-1
+
+      - name: Configure AWS credentials for staging
+        uses: aws-actions/configure-aws-credentials@v2
+        if: env.ENVIRONMENT == 'staging'
+        with:
+          role-to-assume: arn:aws:iam::426579533370:role/github_actions_cloud_image_directory_staging
           role-duration-seconds: 1800
           aws-region: us-east-1
 
@@ -128,4 +201,4 @@ jobs:
             --delete \
             --no-progress \
             --content-type application/json \
-            $(pwd)/raw/azure/ s3://cloudx-json-bucket/raw/azure/
+            $(pwd)/raw/azure/ s3://${BUCKET}/raw/azure/

--- a/.github/workflows/get_google_images.yml
+++ b/.github/workflows/get_google_images.yml
@@ -3,7 +3,19 @@ name: Google Images
 on:
   schedule:
     - cron: "45 5 * * *"
+  push:
+    branches:
+      - main      
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Choose your deployment target environment'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - 'production'
+          - 'staging'
 
 permissions:
   actions: write
@@ -15,11 +27,41 @@ env:
   AWS_PAGER: ""
 
 jobs:
+  setup:
+    name: Setup workflow envs
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.set-environment.outputs.environment }}
+      bucket: ${{ steps.set-bucket.outputs.bucket }}
+    steps:
+      # Only set target environment to production if the workflow is triggered by
+      # a scheduled execution or workflow_dispatch with production input selected
+      - name: Setup target environment
+        id: set-environment
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.environment }}" = "production" ]; then
+            echo "environment=production" >> $GITHUB_OUTPUT
+          else
+            echo "environment=staging" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Setup target bucket
+        # Set target bucket according to target environment
+        id: set-bucket
+        run: |
+          if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ inputs.environment }}" = "production" ]; then
+            echo "bucket=cloudx-json-bucket" >> $GITHUB_OUTPUT
+          else
+            echo "bucket=cid-bucket-staging" >> $GITHUB_OUTPUT
+          fi
+
   list_images:
     name: "List Images"
     runs-on: ubuntu-latest
+    needs: setup
     env:
       REGION: ${{ matrix.region }}
+      ENVIRONMENT: ${{ needs.setup.outputs.environment }}        
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
@@ -27,6 +69,7 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout latest tagged release
+        if: env.ENVIRONMENT == 'production'
         run: |
           LATEST_RELEASE=$(git describe --tags `git rev-list --tags --max-count=1`)
           git checkout $LATEST_RELEASE
@@ -55,10 +98,21 @@ jobs:
   upload_data:
     name: "Upload Data"
     runs-on: ubuntu-latest
-    needs: [list_images]
+    needs: [list_images, setup]
+    env:
+      ENVIRONMENT: ${{ needs.setup.outputs.environment }}
+      BUCKET: ${{ needs.setup.outputs.bucket }}        
     steps:
       - name: Clone repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout latest tagged release
+        if: env.ENVIRONMENT == 'production'
+        run: |
+          LATEST_RELEASE=$(git describe --tags `git rev-list --tags --max-count=1`)
+          git checkout $LATEST_RELEASE
 
       - name: Download image data artifacts
         uses: actions/download-artifact@v3
@@ -68,10 +122,19 @@ jobs:
       - name: Install awscli v2
         uses: unfor19/install-aws-cli-action@v1
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials for production
         uses: aws-actions/configure-aws-credentials@v2
+        if: env.ENVIRONMENT == 'production'
         with:
           role-to-assume: arn:aws:iam::426579533370:role/github_actions_image_retriever
+          role-duration-seconds: 1800
+          aws-region: us-east-1
+
+      - name: Configure AWS credentials for staging
+        uses: aws-actions/configure-aws-credentials@v2
+        if: env.ENVIRONMENT == 'staging'
+        with:
+          role-to-assume: arn:aws:iam::426579533370:role/github_actions_cloud_image_directory_staging
           role-duration-seconds: 1800
           aws-region: us-east-1
 
@@ -88,4 +151,4 @@ jobs:
             --delete \
             --no-progress \
             --content-type application/json \
-            $(pwd)/raw/google/ s3://cloudx-json-bucket/raw/google/
+            $(pwd)/raw/google/ s3://${BUCKET}/raw/google/


### PR DESCRIPTION
This PR adds new workflow execution scenarios.
**staging**
- run on any merge to main (only possible after PR is merged)
- run from workflow dispatch when staging is chosen from the available environments
- will use the latest main code base 
- will push to staging.imagedirectory.cloud

**production**
- run on every scheduled workflow execution
- run from workflow dispatch when production is chosen from the available environments 
- will checkout the latest tag
- will push to imagedirectory.cloud

Closes #11 