### PR TITLE
Only return RHEL GCP images

### DIFF
--- a/.github/workflows/get_google_images.yml
+++ b/.github/workflows/get_google_images.yml
@@ -61,7 +61,7 @@ jobs:
     needs: setup
     env:
       REGION: ${{ matrix.region }}
-      ENVIRONMENT: ${{ needs.setup.outputs.environment }}        
+      ENVIRONMENT: ${{ needs.setup.outputs.environment }}
     steps:
       - name: Clone repo
         uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
 
       - name: Get images
         run: |
-          gcloud compute images list --standard-images --format="json" | jq -c > global.json
+          gcloud compute images list --project=rhel-cloud --no-standard-images --format="json" | jq -c > global.json
           zstd -v global.json
 
       - name: Store image data in artifact
@@ -101,7 +101,7 @@ jobs:
     needs: [list_images, setup]
     env:
       ENVIRONMENT: ${{ needs.setup.outputs.environment }}
-      BUCKET: ${{ needs.setup.outputs.bucket }}        
+      BUCKET: ${{ needs.setup.outputs.bucket }}
     steps:
       - name: Clone repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Additional filters that have been applied:
- remove standard images from return value
- reduce scope to rhel-cloud

This will return the following image families, which are only 4 listings in total:
- RHEL 7 x86
- RHEL 8 x86
- RHEL 9 x86
- RHEL 9 aarch64

This should give us a good baseline until we have decided how we proceed with 3p or product specific listings such as SAP.

[Staging deplyoment results](https://github.com/redhatcloudx/cloud-image-retriever/actions/runs/9443232345).